### PR TITLE
Fix the error in 3.11.4.1

### DIFF
--- a/docs/chapter03_DL-basics/3.11_underfit-overfit.md
+++ b/docs/chapter03_DL-basics/3.11_underfit-overfit.md
@@ -79,7 +79,7 @@ import matplotlib.pyplot as plt
 
 $$y = 1.2x - 3.4x^2 + 5.6x^3 + 5 + \epsilon,$$
 
-其中噪声项$\epsilon$服从均值为0、标准差为0.01的正态分布。训练数据集和测试数据集的样本数都设为100。
+其中噪声项$\epsilon$服从均值为0、标准差为0.1的正态分布。训练数据集和测试数据集的样本数都设为100。
 
 ``` python
 n_train, n_test, true_w, true_b = 100, 100, [1.2, -3.4, 5.6], 5


### PR DESCRIPTION
描述“其中噪声项$\epsilon$服从均值为0、标准差为0.01的正态分布。训练数据集和测试数据集的样本数都设为100”中标准差为0.01与后续计算公式不符，应修改为0.1，原书中表述标准差为0.1.