### PR TITLE
Fix the error in 3.12.4

### DIFF
--- a/docs/chapter03_DL-basics/3.12_weight-decay.md
+++ b/docs/chapter03_DL-basics/3.12_weight-decay.md
@@ -184,7 +184,7 @@ L2 norm of w: 12.86785888671875
 </div>
 
 ``` python
-fit_and_plot_tf2(0, lr)
+fit_and_plot_tf2(3, lr)
 ```
 输出：
 


### PR DESCRIPTION
The last "fit_and_plot_tf2(0, lr)" should be "fit_and_plot_tf2(3, lr)" to change the 'md' parameter. The error is only found in the docs folder. The code in code folder is correct.