### PR TITLE
chapter_9.5 fix bounding box位置不正确问题

### DIFF
--- a/code/chapter09_computer-vision/9.5_multiscale-object-detection.ipynb
+++ b/code/chapter09_computer-vision/9.5_multiscale-object-detection.ipynb
@@ -69,6 +69,8 @@
     "def display_anchors(fmap_w, fmap_h, s):\n",
     "    fmap = np.zeros((1, 10, fmap_w, fmap_h))  # 前两维的取值不影响输出结果\n",
     "    anchors = MultiBoxPrior(fmap, sizes=s, ratios=[1, 2, 0.5])\n",
+    "    offset_x, offset_y = 1.0/fmap_w, 1.0/fmap_h\n",
+    "    anchors += tf.constant([offset_x/2, offset_y/2, offset_x/2, offset_y/2])\n",
     "    bbox_scale = np.array((w, h, w, h))\n",
     "    show_bboxes(plt.imshow(img).axes,\n",
     "                    anchors[0] * bbox_scale)\n",


### PR DESCRIPTION
Hi Tensorflow D2L 团队,

Computer vision 9.5章那个边界框偏移了一点，添加了一点代码让它们能够在图片正确位置显示。

regards
Si Xiong