### PR TITLE
更正7.3的笔误

### DIFF
--- a/docs/chapter07_optimization/7.3_minibatch-sgd.md
+++ b/docs/chapter07_optimization/7.3_minibatch-sgd.md
@@ -179,7 +179,7 @@ def train_tensorflow2_ch7(trainer_name, trainer_hyperparams, features, labels,
 ```
 使用Tensorflow2重复上一个实验。
 ``` python
-train_pytorch_ch7(optim.SGD, {"lr": 0.05}, features, labels, 10)
+train_tensorflow2_ch7('trainer', {'learning_rate': 0.05}, features, labels, 10)
 ```
 输出：
 ```


### PR DESCRIPTION
@archersama    根据[7.3.3有一处笔误 ](https://github.com/TrickyGo/Dive-into-DL-TensorFlow2.0/issues/65)， 更正了笔误。