### PR TITLE
Update 3.12_weight-decay.ipynb

### DIFF
--- a/code/chapter03_DL-basics/3.12_weight-decay.ipynb
+++ b/code/chapter03_DL-basics/3.12_weight-decay.ipynb
@@ -320,14 +320,14 @@
     "    model.compile(optimizer=tf.keras.optimizers.SGD(lr=lr), \n",
     "                 loss=tf.keras.losses.MeanSquaredError())\n",
     "    history = model.fit(train_features, train_labels, epochs=100, batch_size=1, \n",
-    "              validation_data=(test_features, test_labels),\n",
-    "             validation_freq=1,verbose=0)\n",
+    "                        validation_data=(test_features, test_labels),\n",
+    "                        validation_freq=1,verbose=0)\n",
     "    # model.summary()\n",
     "    train_ls = history.history['loss']\n",
     "    test_ls = history.history['val_loss']\n",
     "    # print(test_ls)\n",
-    "    semilogy(range(1, num_epochs + 1), train_ls, 'epochs', 'loss',\n",
-    "                     range(1, num_epochs + 1), test_ls, ['train', 'test'])\n",
+    "    d2l.semilogy(range(1, num_epochs + 1), train_ls, 'epochs', 'loss',\n",
+    "                 range(1, num_epochs + 1), test_ls, ['train', 'test'])\n",
     "    print('L2 norm of w:', tf.norm(model.get_weights()[0]).numpy())"
    ]
   },


### PR DESCRIPTION
1. 代码空格没有对齐，不规范
2. semilogy 前应该有 d2l. ，这里缺失
3. 在网页版中，semilogy 前添加的是 dl2. ，不是 d2l. ，这导致代码运行错误。