### PR TITLE
Update 3.12_weight-decay.ipynb

### DIFF
--- a/code/chapter03_DL-basics/3.12_weight-decay.ipynb
+++ b/code/chapter03_DL-basics/3.12_weight-decay.ipynb
@@ -317,7 +317,7 @@
     "    model.add(tf.keras.layers.Dense(1, \n",
     "                                    kernel_regularizer=regularizers.l2(wd), \n",
     "                                    bias_regularizer=None))\n",
-    "    model.compile(optimizer=tf.keras.optimizers.SGD(lr=lr), \n",
+    "    model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr), \n",
     "                 loss=tf.keras.losses.MeanSquaredError())\n",
     "    history = model.fit(train_features, train_labels, epochs=100, batch_size=1, \n",
     "              validation_data=(test_features, test_labels),\n",


### PR DESCRIPTION
在 tensorflow 2.11.0 中，`lr` 已经被抛弃了，应该使用 `learning_rate` 运行代码给出警告如下：
WARNING:absl:`lr` is deprecated, please use `learning_rate` instead, or use the legacy optimizer, e.g.,tf.keras.optimizers.legacy.SGD.