### PR TITLE
Update 3.16_kaggle-house-price.ipynb

### DIFF
--- a/code/chapter03_DL-basics/3.16_kaggle-house-price.ipynb
+++ b/code/chapter03_DL-basics/3.16_kaggle-house-price.ipynb
@@ -292,9 +292,9 @@
    "outputs": [],
    "source": [
     "n_train = train_data.shape[0]\n",
-    "train_features = np.array(all_features[:n_train].values,dtype=np.float)\n",
-    "test_features = np.array(all_features[n_train:].values,dtype=np.float)\n",
-    "train_labels = np.array(train_data.SalePrice.values.reshape(-1, 1),dtype=np.float)"
+    "train_features = np.array(all_features[:n_train].values,dtype=float)\n",
+    "test_features = np.array(all_features[n_train:].values,dtype=float)\n",
+    "train_labels = np.array(train_data.SalePrice.values.reshape(-1, 1),dtype=float)"
    ]
   },
   {


### PR DESCRIPTION
np.float 在 numpy 1.20 中被抛弃，这里应使用 float 或 np.float64

执行代码时的报错如下：
AttributeError: module 'numpy' has no attribute 'float'. 
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations