### PR TITLE
Update 3.13_dropout.ipynb

### DIFF
--- a/code/chapter03_DL-basics/3.13_dropout.ipynb
+++ b/code/chapter03_DL-basics/3.13_dropout.ipynb
@@ -275,7 +275,7 @@
         "    H1 = tf.nn.relu(tf.matmul(X, W1) + b1)\n",
         "    if is_training:# 只在训练模型时使用丢弃法\n",
         "      H1 = dropout(H1, drop_prob1)  # 在第一层全连接后添加丢弃层\n",
-        "    H2 = nn.relu(tf.matmul(H1, W2) + b2)\n",
+        "    H2 = tf.nn.relu(tf.matmul(H1, W2) + b2)\n",
         "    if is_training:\n",
         "      H2 = dropout(H2, drop_prob2)  # 在第二层全连接后添加丢弃层\n",
         "    return tf.math.softmax(tf.matmul(H2, W3) + b3)"
@@ -377,7 +377,7 @@
         "                params[0].assign_sub(grads[0] * lr)\n",
         "                params[1].assign_sub(grads[1] * lr)\n",
         "            else:\n",
-        "                trainer.apply_gradients(zip(grads, params))  # “softmax回归的简洁实现”一节将用到\n",
+        "                trainer.apply_gradients(zip(grads, params))  # 3.6.7 “softmax回归的从零开始实现-训练模型” 中使用过\n",
         "\n",
         "            y = tf.cast(y, dtype=tf.float32)\n",
         "            train_l_sum += l.numpy()\n",


### PR DESCRIPTION
1. 添加 tf. 使上下文保持一致，美观
2. trainer.apply_gradients() 函数在 3.7 softmax回归的简洁实现中没有使用，应改为 3.6.7 softmax回归的从零开始实现-训练模型